### PR TITLE
fix: enable editing for dynamic container components

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -43,6 +43,11 @@ export class Constants {
     public static readonly _RESPONSIVE_GRID_PLACEHOLDER_CLASS_NAMES = 'aem-Grid-newComponent';
 
     /**
+     * Event which indicates that content of remote component has been fetched and loaded in the app
+     */
+    public static readonly REMOTE_CONTENT_LOADED = 'cq-remotecontent-loaded';
+
+    /**
      * Selector for WCM mode state meta property.
      */
     public static readonly _WCM_MODE_META_SELECTOR = 'meta[property="cq:wcmmode"]';

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -45,7 +45,7 @@ export class Constants {
     /**
      * Event which indicates that content of remote component has been fetched and loaded in the app
      */
-    public static readonly REMOTE_CONTENT_LOADED_EVENT = 'cq-remotecontent-loaded';
+    public static readonly ASYNC_CONTENT_LOADED_EVENT = 'cq-async-content-loaded';
 
     /**
      * Selector for WCM mode state meta property.

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -45,7 +45,7 @@ export class Constants {
     /**
      * Event which indicates that content of remote component has been fetched and loaded in the app
      */
-    public static readonly REMOTE_CONTENT_LOADED = 'cq-remotecontent-loaded';
+    public static readonly REMOTE_CONTENT_LOADED_EVENT = 'cq-remotecontent-loaded';
 
     /**
      * Selector for WCM mode state meta property.

--- a/src/components/ModelProvider.tsx
+++ b/src/components/ModelProvider.tsx
@@ -91,8 +91,8 @@ export class ModelProvider extends Component<ModelProviderType> {
               this.setState(props);
 
               // Fire event once component model has been fetched and rendered to enable editing on AEM
-              if (injectPropsOnInit) {
-                  PathUtils.dispatchGlobalCustomEvent(Constants.REMOTE_CONTENT_LOADED, {});
+              if (injectPropsOnInit && Utils.isInEditor()) {
+                  PathUtils.dispatchGlobalCustomEvent(Constants.REMOTE_CONTENT_LOADED_EVENT, {});
               }
           }
         }).catch((error) => {

--- a/src/components/ModelProvider.tsx
+++ b/src/components/ModelProvider.tsx
@@ -92,7 +92,7 @@ export class ModelProvider extends Component<ModelProviderType> {
 
               // Fire event once component model has been fetched and rendered to enable editing on AEM
               if (injectPropsOnInit && Utils.isInEditor()) {
-                  PathUtils.dispatchGlobalCustomEvent(Constants.REMOTE_CONTENT_LOADED_EVENT, {});
+                  PathUtils.dispatchGlobalCustomEvent(Constants.ASYNC_CONTENT_LOADED_EVENT, {});
               }
           }
         }).catch((error) => {

--- a/src/components/ModelProvider.tsx
+++ b/src/components/ModelProvider.tsx
@@ -10,9 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import { Model, ModelManager } from '@adobe/aem-spa-page-model-manager';
+import { Model, ModelManager, PathUtils } from '@adobe/aem-spa-page-model-manager';
 import React, { Component } from 'react';
 import isEqual from 'react-fast-compare';
+import { Constants } from '../Constants';
 import { MappedComponentProperties, ReloadForceAble } from '../ComponentMapping';
 import Utils from '../Utils';
 
@@ -88,6 +89,11 @@ export class ModelProvider extends Component<ModelProviderType> {
               const props = Utils.modelToProps(data);
 
               this.setState(props);
+
+              // Fire event once component model has been fetched and rendered to enable editing on AEM
+              if (injectPropsOnInit) {
+                  PathUtils.dispatchGlobalCustomEvent(Constants.REMOTE_CONTENT_LOADED, {});
+              }
           }
         }).catch((error) => {
             console.log(error);

--- a/test/ModelProvider.test.tsx
+++ b/test/ModelProvider.test.tsx
@@ -10,12 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { ModelManager } from '@adobe/aem-spa-page-model-manager';
+import { ModelManager, PathUtils } from '@adobe/aem-spa-page-model-manager';
 import React, { Component } from 'react';
 import { waitFor } from '@testing-library/dom';
 import ReactDOM from 'react-dom';
 import { MappedComponentProperties } from '../src/ComponentMapping';
 import { ModelProvider, withModel } from '../src/components/ModelProvider';
+import { Constants } from '../src/Constants';
 
 describe('ModelProvider ->', () => {
     const TEST_PAGE_PATH = '/page/jcr:content/root';
@@ -152,7 +153,9 @@ describe('ModelProvider ->', () => {
             expect(childNode).toBeDefined();
         });
 
-        it('should render a subpage properly when page path is provided', () => {
+        it('should render a subpage properly when page path is provided', async () => {
+            const dispatchEventSpy: jest.SpyInstance =
+                jest.spyOn(PathUtils, 'dispatchGlobalCustomEvent').mockImplementation();
 
             const DummyWithModel = withModel(Dummy, { injectPropsOnInit: true });
 
@@ -164,6 +167,10 @@ describe('ModelProvider ->', () => {
             const childNode = rootNode.querySelector('#' + INNER_COMPONENT_ID);
 
             expect(childNode).toBeDefined();
+
+            await waitFor(() =>
+                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED, {})
+            );
         });
 
         it('should render components properly when component cqPath is provided', () => {

--- a/test/ModelProvider.test.tsx
+++ b/test/ModelProvider.test.tsx
@@ -241,7 +241,7 @@ describe('ModelProvider ->', () => {
             expect(childNode).toBeDefined();
 
             await waitFor(() =>
-                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED_EVENT, {})
+                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.ASYNC_CONTENT_LOADED_EVENT, {})
             );
 
             isInEditor.mockReset();

--- a/test/ModelProvider.test.tsx
+++ b/test/ModelProvider.test.tsx
@@ -169,7 +169,7 @@ describe('ModelProvider ->', () => {
             expect(childNode).toBeDefined();
 
             await waitFor(() =>
-                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED, {})
+                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED_EVENT, {})
             );
         });
 

--- a/test/ModelProvider.test.tsx
+++ b/test/ModelProvider.test.tsx
@@ -154,11 +154,7 @@ describe('ModelProvider ->', () => {
             expect(childNode).toBeDefined();
         });
 
-        it('should render a subpage properly when page path is provided', async () => {
-            const dispatchEventSpy: jest.SpyInstance =
-                jest.spyOn(PathUtils, 'dispatchGlobalCustomEvent').mockImplementation();
-            const isInEditor:jest.SpyInstance = jest.spyOn(Utils, 'isInEditor').mockImplementation(() => true);
-
+        it('should render a subpage properly when page path is provided', () => {
             const DummyWithModel = withModel(Dummy, { injectPropsOnInit: true });
 
             // @ts-ignore
@@ -169,13 +165,6 @@ describe('ModelProvider ->', () => {
             const childNode = rootNode.querySelector('#' + INNER_COMPONENT_ID);
 
             expect(childNode).toBeDefined();
-
-            await waitFor(() =>
-                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED_EVENT, {})
-            );
-
-            isInEditor.mockReset();
-            dispatchEventSpy.mockReset();
         });
 
         it('should render components properly when component cqPath is provided', () => {
@@ -233,6 +222,30 @@ describe('ModelProvider ->', () => {
 
             // then
             await waitFor(() => expect(console.log).toHaveBeenCalledWith(error));
+        });
+
+        it('should fire event to reload editables when in editor', async () => {
+            const dispatchEventSpy: jest.SpyInstance =
+                jest.spyOn(PathUtils, 'dispatchGlobalCustomEvent').mockImplementation();
+            const isInEditor:jest.SpyInstance = jest.spyOn(Utils, 'isInEditor').mockImplementation(() => true);
+
+            const DummyWithModel = withModel(Dummy, { injectPropsOnInit: true });
+
+            // @ts-ignore
+            ReactDOM.render(<DummyWithModel pagePath={TEST_PAGE_PATH}></DummyWithModel>, rootNode);
+
+            expect(getDataSpy).toHaveBeenCalledWith({ path: TEST_PAGE_PATH, forceReload: false });
+
+            const childNode = rootNode.querySelector('#' + INNER_COMPONENT_ID);
+
+            expect(childNode).toBeDefined();
+
+            await waitFor(() =>
+                expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED_EVENT, {})
+            );
+
+            isInEditor.mockReset();
+            dispatchEventSpy.mockReset();
         });
     });
 

--- a/test/ModelProvider.test.tsx
+++ b/test/ModelProvider.test.tsx
@@ -17,6 +17,7 @@ import ReactDOM from 'react-dom';
 import { MappedComponentProperties } from '../src/ComponentMapping';
 import { ModelProvider, withModel } from '../src/components/ModelProvider';
 import { Constants } from '../src/Constants';
+import Utils from '../src/Utils';
 
 describe('ModelProvider ->', () => {
     const TEST_PAGE_PATH = '/page/jcr:content/root';
@@ -156,6 +157,7 @@ describe('ModelProvider ->', () => {
         it('should render a subpage properly when page path is provided', async () => {
             const dispatchEventSpy: jest.SpyInstance =
                 jest.spyOn(PathUtils, 'dispatchGlobalCustomEvent').mockImplementation();
+            const isInEditor:jest.SpyInstance = jest.spyOn(Utils, 'isInEditor').mockImplementation(() => true);
 
             const DummyWithModel = withModel(Dummy, { injectPropsOnInit: true });
 
@@ -171,6 +173,9 @@ describe('ModelProvider ->', () => {
             await waitFor(() =>
                 expect(dispatchEventSpy).toHaveBeenCalledWith(Constants.REMOTE_CONTENT_LOADED_EVENT, {})
             );
+
+            isInEditor.mockReset();
+            dispatchEventSpy.mockReset();
         });
 
         it('should render components properly when component cqPath is provided', () => {


### PR DESCRIPTION
## Description

Fire event once component model has been fetched and rendered, to reload editables and enable
editing within AEM.

## Motivation and Context

To resolve editing being disabled when editables and page model have been loaded before the component has rendered fully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.