### PR TITLE
Integrating StyleSystem Classes for Component Wrapper div tags in SPA Editor - React Impl

### DIFF
--- a/src/ComponentMapping.tsx
+++ b/src/ComponentMapping.tsx
@@ -41,7 +41,6 @@ export interface ReloadForceAble {
 export interface MappedComponentProperties extends ReloadForceAble {
     isInEditor: boolean;
     cqPath: string;
-    cssClassNames?: string;
     appliedCssClassNames?: string;
 }
 

--- a/src/ComponentMapping.tsx
+++ b/src/ComponentMapping.tsx
@@ -41,6 +41,8 @@ export interface ReloadForceAble {
 export interface MappedComponentProperties extends ReloadForceAble {
     isInEditor: boolean;
     cqPath: string;
+    cssClassNames?: string;
+    appliedCssClassNames?: string;
 }
 
 /**

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -35,11 +35,6 @@ export class Constants {
     /**
      * Default CSS Class names associated with a component.
      */
-    public static readonly DEFAULT_CLASS_NAMES = 'cssClassNames';
-
-    /**
-     * Default CSS Class names associated with a component.
-     */
     public static readonly APPLIED_CLASS_NAMES = 'appliedCssClassNames';
 
     /**

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -31,6 +31,17 @@ export class Constants {
      * Class names associated with a new section component.
      */
     public static readonly NEW_SECTION_CLASS_NAMES = 'new section';
+
+    /**
+     * Default CSS Class names associated with a component.
+     */
+    public static readonly DEFAULT_CLASS_NAMES = 'cssClassNames';
+
+    /**
+     * Default CSS Class names associated with a component.
+     */
+    public static readonly APPLIED_CLASS_NAMES = 'appliedCssClassNames';
+
     /**
      * Class name used to denote aem-container root element.
      */

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -88,11 +88,7 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         const sProps: { [key: string]: string } = { className: '' };
         const componentProperties: P = this.props.componentProperties;
 
-        const defaultClassNames = componentProperties[Constants.DEFAULT_CLASS_NAMES];
         const appliedCssClassNames = componentProperties[Constants.APPLIED_CLASS_NAMES];
-
-        if (defaultClassNames)
-            sProps.className += defaultClassNames + ' ';
 
         if (appliedCssClassNames)
             sProps.className += appliedCssClassNames + ' ';

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -81,6 +81,25 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         return eProps;
     }
 
+    /**
+     * Properties related to styling of the component.
+     */
+    get styleProps(): { [key: string]: string } {
+        const sProps: { [key: string]: string } = { className: '' };
+        const componentProperties: P = this.props.componentProperties;
+
+        const defaultClassNames = componentProperties[Constants.DEFAULT_CLASS_NAMES];
+        const appliedCssClassNames = componentProperties[Constants.APPLIED_CLASS_NAMES];
+
+        if (defaultClassNames)
+            sProps.className += defaultClassNames + ' ';
+
+        if (appliedCssClassNames)
+            sProps.className += appliedCssClassNames + ' ';
+
+        return sProps;
+    }
+
     protected get emptyPlaceholderProps() {
         if (!this.useEmptyPlaceholder()) {
             return null;
@@ -107,7 +126,7 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         const WrappedComponent: React.ComponentType<any> = this.props.wrappedComponent;
 
         return (
-          <div {...this.editProps} {...this.props.containerProps}>
+          <div {...this.editProps} {...{ ...this.props.containerProps, ...this.styleProps }} >
             <WrappedComponent {...this.state}/>
             <div {...this.emptyPlaceholderProps}/>
           </div>

--- a/test/EditableComponent.test.tsx
+++ b/test/EditableComponent.test.tsx
@@ -22,6 +22,7 @@ describe('EditableComponent ->', () => {
     const COMPONENT_RESOURCE_TYPE = '/component/resource/type';
     const COMPONENT_PATH = '/path/to/component';
     const CHILD_COMPONENT_CLASS_NAME = 'child-class';
+    const CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME = 'my_custom_style';
     const IN_EDITOR_CLASS_NAME = 'in-editor-class';
     const EMPTY_LABEL = 'Empty Label';
     const EMPTY_TEXT_SELECTOR = '[data-emptytext="' + EMPTY_LABEL + '"]';
@@ -30,7 +31,8 @@ describe('EditableComponent ->', () => {
 
     const CQ_PROPS = {
         'cqType': COMPONENT_RESOURCE_TYPE,
-        'cqPath': COMPONENT_PATH
+        'cqPath': COMPONENT_PATH,
+        'appliedCssClassNames' : CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME
     };
 
     let rootNode: any;
@@ -186,6 +188,47 @@ describe('EditableComponent ->', () => {
             ReactDOM.render(<EditableComponent isInEditor={true} {...CQ_PROPS}/>, rootNode);
 
             const node = rootNode.querySelector(DATA_RESOURCE_TYPE_SELECTOR);
+
+            expect(node).toBeNull();
+        });
+    });
+
+    describe('resouceType attribute ->', () => {
+
+        it('should have the className attribute containing appliedCssClasses value appended/set to pre-existing className if any set', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return false;
+                },
+                emptyLabel: EMPTY_LABEL,
+                resourceType: COMPONENT_RESOURCE_TYPE
+            };
+
+            const EditableComponent: any = withEditable(ChildComponent, EDIT_CONFIG);
+
+            ReactDOM.render(<EditableComponent isInEditor={true} {...CQ_PROPS}/>, rootNode);
+
+            const node = rootNode.querySelector(DATA_PATH_ATTRIBUTE_SELECTOR + '.' + CQ_PROPS.appliedCssClassNames);
+
+            expect(node).not.toBeNull();
+        });
+
+        it('should not have any custom CSS classes if appliedCssClasses is empty or not set', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return false;
+                },
+                emptyLabel: EMPTY_LABEL,
+                resourceType: COMPONENT_RESOURCE_TYPE
+            };
+
+            const EditableComponent: any = withEditable(ChildComponent, EDIT_CONFIG);
+
+            const { appliedCssClassNames, ...otherCQProps } = CQ_PROPS;
+
+            ReactDOM.render(<EditableComponent isInEditor={true} {...otherCQProps} />, rootNode);
+
+            const node = rootNode.querySelector(DATA_PATH_ATTRIBUTE_SELECTOR + '.' + appliedCssClassNames);
 
             expect(node).toBeNull();
         });


### PR DESCRIPTION
## Description

Changes done to EditableComponent to support StyleSystem based on appliedCssClassNames property from Sling Model exporters. Please refer to related issue for more details.

## Related Issue

Here is the related issue requesting this feature. #68 

## Motivation and Context

These changes extend the style system capability/feature to SPA Editor implementation for React apps.

## How Has This Been Tested?

Changes done locally and deployed to AEM instance via a brand new project to confirm that stysystem works as expected. Related issue #68 has screenshots of these tests. Aditionally unit tests are also included to validate this behavior.

## Screenshots (if appropriate):

Refer to related issue.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional Notes

If this PR is approved/merged, the page below requires updates against limitations section where we now can support StyleSystem. Additionally we need to include documentation for using style system with examples either in the next archetype or in WKND events sample project. Additionally we need to capture the need for registering the property appliedCssClassNames against any custom sling model that needs style system capability.