### PR TITLE
Support for component no decoration (aemNoDecoration)

### DIFF
--- a/src/ComponentMapping.tsx
+++ b/src/ComponentMapping.tsx
@@ -42,6 +42,7 @@ export interface MappedComponentProperties extends ReloadForceAble {
     isInEditor: boolean;
     cqPath: string;
     appliedCssClassNames?: string;
+    aemNoDecoration?: boolean;
 }
 
 /**

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -149,11 +149,24 @@ export class Container<P extends ContainerProperties, S extends ContainerState> 
     }
 
     public render() {
-        return (
-            <div {...this.containerProps}>
-                { this.childComponents }
-                { this.placeholderComponent }
-            </div>
-        );
+        let renderScript;
+
+        if (!this.props.isInEditor && this.props.aemNoDecoration){
+            renderScript = (
+                <React.Fragment>
+                    { this.childComponents }
+                    { this.placeholderComponent }
+                </React.Fragment>
+            )
+        } else {
+            renderScript = (
+                <div {...this.containerProps}>
+                    { this.childComponents }
+                    { this.placeholderComponent }
+                </div>
+            )
+        }
+
+        return renderScript;
     }
 }

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -121,12 +121,26 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
     public render() {
         const WrappedComponent: React.ComponentType<any> = this.props.wrappedComponent;
 
-        return (
-          <div {...this.editProps} {...{ ...this.props.containerProps, ...this.styleProps }} >
-            <WrappedComponent {...this.state}/>
-            <div {...this.emptyPlaceholderProps}/>
-          </div>
-        );
+        const componentProperties: P = this.props.componentProperties;
+        let renderScript;
+
+        if (!componentProperties.isInEditor && componentProperties.aemNoDecoration){
+            renderScript = (
+                <React.Fragment>
+                  <WrappedComponent {...this.state}/>
+                  <div {...this.emptyPlaceholderProps}/>
+                </React.Fragment>
+              )
+        } else {
+            renderScript = (
+                <div {...this.editProps} {...{ ...this.props.containerProps, ...this.styleProps }} >
+                  <WrappedComponent {...this.state}/>
+                  <div {...this.emptyPlaceholderProps}/>
+                </div>
+              )
+        }
+
+        return renderScript;
     }
 }
 

--- a/test/EditableComponent.test.tsx
+++ b/test/EditableComponent.test.tsx
@@ -233,4 +233,25 @@ describe('EditableComponent ->', () => {
             expect(node).toBeNull();
         });
     });
+
+    describe('component decoration ->', () => {
+
+        it('if aemNoDecoration is set to true, there should not be a component div wrapper', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return false;
+                },
+                emptyLabel: EMPTY_LABEL,
+                resourceType: COMPONENT_RESOURCE_TYPE
+            };
+
+            const EditableComponent: any = withEditable(ChildComponent, EDIT_CONFIG);
+
+            ReactDOM.render(<EditableComponent isInEditor={false} aemNoDecoration={true} {...CQ_PROPS}/>, rootNode);
+
+            const node = rootNode.querySelector('.' + CQ_PROPS.appliedCssClassNames);
+
+            expect(node).toBeNull();
+        });
+    });
 });

--- a/test/components/Container.test.tsx
+++ b/test/components/Container.test.tsx
@@ -135,4 +135,16 @@ describe('Container ->', () => {
             expect(container).toBeDefined();
         });
     });
+
+    describe('container decoration ->', () => {
+
+        it('if aemNoDecoration is set to true, there should not be a container div wrapper', () => {
+            ReactDOM.render(<Container componentMapping={ComponentMapping} cqPath={CONTAINER_PATH} isInEditor={false} aemNoDecoration={true}/>, rootNode);
+
+            const container = rootNode.querySelector('.aem-container');
+
+            expect(container).toBeNull();
+        });
+    });
+
 });


### PR DESCRIPTION
## Description

Server side html generation in AEM supports cq:NoDecoration. https://experienceleague.adobe.com/docs/experience-manager-65/developing/components/decoration-tag.html?lang=en

This pull request is for adding similar support in React SPA libs...

## Related Issue

https://github.com/adobe/aem-react-editable-components/issues/74

## Motivation and Context

Creating fluid flex layouts with component nesting is becoming complicated due to the wrappers (serving no purpose)

## How Has This Been Tested?

Tested on AEM SDK. The custom component should provide  a sling model for adding aemNoDecoration property in the model json response (Core components sling models were not modified to introduce this property)

![image](https://user-images.githubusercontent.com/6585493/130264866-7dd7496c-e326-4111-8f9f-df930aeaf038.png)

![image](https://user-images.githubusercontent.com/6585493/130264992-b62396ad-3664-40b1-91dc-4bf7806a0905.png)

![image](https://user-images.githubusercontent.com/6585493/130265098-6fd4f8f2-3111-4cce-a55b-2fe878738cf5.png)

![image](https://user-images.githubusercontent.com/6585493/130265212-06dd621c-546d-45dc-ac3c-11813dca28b6.png)

![image](https://user-images.githubusercontent.com/6585493/130265293-97aafb83-cd1e-4eee-a88e-99263e84665d.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
