### PR TITLE
Fix for #78

### DIFF
--- a/src/ComponentMapping.tsx
+++ b/src/ComponentMapping.tsx
@@ -42,6 +42,7 @@ export interface MappedComponentProperties extends ReloadForceAble {
     isInEditor: boolean;
     cqPath: string;
     appliedCssClassNames?: string;
+    aemNoDecoration?: boolean;
 }
 
 /**

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -149,11 +149,24 @@ export class Container<P extends ContainerProperties, S extends ContainerState> 
     }
 
     public render() {
-        return (
-            <div {...this.containerProps}>
-                { this.childComponents }
-                { this.placeholderComponent }
-            </div>
-        );
+        let renderScript;
+
+        if (!this.props.isInEditor && this.props.aemNoDecoration){
+            renderScript = (
+                <React.Fragment>
+                    { this.childComponents }
+                    { this.placeholderComponent }
+                </React.Fragment>
+            )
+        } else {
+            renderScript = (
+                <div {...this.containerProps}>
+                    { this.childComponents }
+                    { this.placeholderComponent }
+                </div>
+            )
+        }
+
+        return renderScript;
     }
 }

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -155,7 +155,6 @@ export class Container<P extends ContainerProperties, S extends ContainerState> 
             renderScript = (
                 <React.Fragment>
                     { this.childComponents }
-                    { this.placeholderComponent }
                 </React.Fragment>
             )
         } else {

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -93,6 +93,10 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         if (appliedCssClassNames)
             sProps.className += appliedCssClassNames + ' ';
 
+        if (this.props.containerProps && this.props.containerProps.className){
+            sProps.className = sProps.className + ' ' + this.props.containerProps.className;
+        }
+    
         return sProps;
     }
 
@@ -128,7 +132,6 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
             renderScript = (
                 <React.Fragment>
                   <WrappedComponent {...this.state}/>
-                  <div {...this.emptyPlaceholderProps}/>
                 </React.Fragment>
               )
         } else {

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -121,12 +121,26 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
     public render() {
         const WrappedComponent: React.ComponentType<any> = this.props.wrappedComponent;
 
-        return (
-          <div {...this.editProps} {...{ ...this.props.containerProps, ...this.styleProps }} >
-            <WrappedComponent {...this.state}/>
-            <div {...this.emptyPlaceholderProps}/>
-          </div>
-        );
+        const componentProperties: P = this.props.componentProperties;
+        let renderScript;
+
+        if (!componentProperties.isInEditor && componentProperties.aemNoDecoration){
+            renderScript = (
+                <React.Fragment>
+                  <WrappedComponent {...this.state}/>
+                  <div {...this.emptyPlaceholderProps}/>
+                </React.Fragment>
+              )
+        } else {
+            renderScript = (
+                <div {...this.editProps} {...{ ...this.props.containerProps, ...this.styleProps }} >
+                  <WrappedComponent {...this.state}/>
+                  <div {...this.emptyPlaceholderProps}/>
+                </div>
+              )
+        }
+
+        return renderScript;
     }
 }
 

--- a/test/EditableComponent.test.tsx
+++ b/test/EditableComponent.test.tsx
@@ -233,4 +233,25 @@ describe('EditableComponent ->', () => {
             expect(node).toBeNull();
         });
     });
+
+    describe('component decoration ->', () => {
+
+        it('if aemNoDecoration is set to true, there should not be a component div wrapper', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return false;
+                },
+                emptyLabel: EMPTY_LABEL,
+                resourceType: COMPONENT_RESOURCE_TYPE
+            };
+
+            const EditableComponent: any = withEditable(ChildComponent, EDIT_CONFIG);
+
+            ReactDOM.render(<EditableComponent isInEditor={false} aemNoDecoration={true} {...CQ_PROPS}/>, rootNode);
+
+            const node = rootNode.querySelector('.' + CQ_PROPS.appliedCssClassNames);
+
+            expect(node).toBeNull();
+        });
+    });
 });

--- a/test/components/Container.test.tsx
+++ b/test/components/Container.test.tsx
@@ -135,4 +135,16 @@ describe('Container ->', () => {
             expect(container).toBeDefined();
         });
     });
+
+    describe('container decoration ->', () => {
+
+        it('if aemNoDecoration is set to true, there should not be a container div wrapper', () => {
+            ReactDOM.render(<Container componentMapping={ComponentMapping} cqPath={CONTAINER_PATH} isInEditor={false} aemNoDecoration={true}/>, rootNode);
+
+            const container = rootNode.querySelector('.aem-container');
+
+            expect(container).toBeNull();
+        });
+    });
+
 });


### PR DESCRIPTION

## Description

PR fixes the issue #78 (component style system overriding grid classes)

## Related Issue

https://github.com/adobe/aem-react-editable-components/issues/78

## Motivation and Context

Allows authors to configure components for various breakpoints

## How Has This Been Tested?

1) Created a template with Desktop and other breakpoints (eg. Tablet, Mobile....)
2) Added a sample component on a page created using template in step 1
3) Configured the component on various breakpoints eg. Tablet
4) In View source the breakpoint grid styles are added...

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6585493/131560835-1006fa36-247d-446e-9df5-45063dac1438.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
