### PR TITLE
Issue 78 : fix for component styles overriding grid styles

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -155,7 +155,6 @@ export class Container<P extends ContainerProperties, S extends ContainerState> 
             renderScript = (
                 <React.Fragment>
                     { this.childComponents }
-                    { this.placeholderComponent }
                 </React.Fragment>
             )
         } else {

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -93,7 +93,7 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         if (appliedCssClassNames)
             sProps.className += appliedCssClassNames + ' ';
 
-        if (this.props.containerProps && this.props.containerProps.className){
+        if (this.props?.containerProps?.className){
             sProps.className = sProps.className + ' ' + this.props.containerProps.className;
         }
     
@@ -130,9 +130,7 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
 
         if (!componentProperties.isInEditor && componentProperties.aemNoDecoration){
             renderScript = (
-                <React.Fragment>
                   <WrappedComponent {...this.state}/>
-                </React.Fragment>
               )
         } else {
             renderScript = (

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -93,6 +93,10 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
         if (appliedCssClassNames)
             sProps.className += appliedCssClassNames + ' ';
 
+        if (this.props.containerProps && this.props.containerProps.className){
+            sProps.className = sProps.className + ' ' + this.props.containerProps.className;
+        }
+    
         return sProps;
     }
 
@@ -128,7 +132,6 @@ class EditableComponent<P extends MappedComponentProperties, S extends Container
             renderScript = (
                 <React.Fragment>
                   <WrappedComponent {...this.state}/>
-                  <div {...this.emptyPlaceholderProps}/>
                 </React.Fragment>
               )
         } else {

--- a/test/EditableComponent.test.tsx
+++ b/test/EditableComponent.test.tsx
@@ -24,6 +24,7 @@ describe('EditableComponent ->', () => {
     const CHILD_COMPONENT_CLASS_NAME = 'child-class';
     const CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME = 'my_custom_style';
     const IN_EDITOR_CLASS_NAME = 'in-editor-class';
+    const GRID_CLASS_NAME = 'aem-grid-column-x';
     const EMPTY_LABEL = 'Empty Label';
     const EMPTY_TEXT_SELECTOR = '[data-emptytext="' + EMPTY_LABEL + '"]';
     const DATA_PATH_ATTRIBUTE_SELECTOR = '[data-cq-data-path="' + COMPONENT_PATH + '"]';
@@ -32,7 +33,10 @@ describe('EditableComponent ->', () => {
     const CQ_PROPS = {
         'cqType': COMPONENT_RESOURCE_TYPE,
         'cqPath': COMPONENT_PATH,
-        'appliedCssClassNames' : CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME
+        'appliedCssClassNames' : CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME,
+        containerProps:{
+            className: GRID_CLASS_NAME
+        }
     };
 
     let rootNode: any;
@@ -231,6 +235,24 @@ describe('EditableComponent ->', () => {
             const node = rootNode.querySelector(DATA_PATH_ATTRIBUTE_SELECTOR + '.' + appliedCssClassNames);
 
             expect(node).toBeNull();
+        });
+
+        it('if aem grid column styles set, appliedCssClassNames should not override the grid styles', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return false;
+                },
+                emptyLabel: EMPTY_LABEL,
+                resourceType: COMPONENT_RESOURCE_TYPE
+            };
+
+            const EditableComponent: any = withEditable(ChildComponent, EDIT_CONFIG);
+
+            ReactDOM.render(<EditableComponent isInEditor={true} {...CQ_PROPS}/>, rootNode);
+
+            const node = rootNode.querySelector('.' + GRID_CLASS_NAME);
+
+            expect(node).not.toBeNull();
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

PR fixes the issue #78 (component style system overriding grid classes)

## Related Issue

https://github.com/adobe/aem-react-editable-components/issues/78

## Motivation and Context

Allows authors to configure components for various breakpoints

## How Has This Been Tested?

1. Created a template with Desktop and other breakpoints (eg. Tablet, Mobile....)
2. Added a sample component on a page created using template in step 1
3. Configured the component on various breakpoints eg. Tablet
4. In View source the breakpoint grid styles are added...

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6585493/131583246-0771521d-b49a-4661-a2cc-0c7294d6d255.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
