### PR TITLE
chore: fixing typedoc run failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:types": "tsc -p src/tsconfig.types.json",
     "build": "npm run clean && npm run linter && webpack && npm run build:types",
     "clean": "rm -rf dist/",
-    "docs": "npm i && npx typedoc --excludePrivate ./src --out ./dist/docs",
+    "docs": "npm i && npx typedoc ./src/types.ts --excludePrivate ./src --out ./dist/docs",
     "linter": "eslint .",
     "semantic-release": "semantic-release",
     "test:coverage": "jest --clearCache && jest --coverage",
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "path-browserify": "^1.0.1",
-    "prop-types": "^15.7.2",
     "react-fast-compare": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

- Fixing build failure due to typedoc being unable to find entrypoint
- Remove duplication of prop-types in package.json

## Related Issue


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
