### PR TITLE
fix: transpilation target incompatible with CRA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/aem-react-editable-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/aem-react-editable-components",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aem-spa-component-mapping": "~1.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2022",
+    "target": "ES6",
     "declaration": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Changes the target in tsconfig to `ES6` for compatibility with [create-react-app](https://create-react-app.dev/).

## Description

Changing the compilation target to `ES6`, as this is supported by create-react-app. The TS docs also suggest using this target: https://www.typescriptlang.org/tsconfig#target

## Related Issue

Fixes https://github.com/adobe/aem-react-editable-components/issues/133

## How Has This Been Tested?

Tested in 2 ways:

1. See the related issue for reproduction steps. Reproduce the issue to confirm that it occurs. Then, install the fixed version using `npm link`. The issue is resolved
2. In the context of https://jira.corp.adobe.com/browse/SITES-7938, refactoring the SPA editor example at https://github.com/adobe/aem-guides-wknd-graphql/tree/feature/spa-editor to use `aem-react-editable-components` v2.x. Tested to be working in the context of that project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
