### PR TITLE
The `jcr:title` of the component should be used in Template Editor in the Allowed Component section.

### DIFF
--- a/src/components/AllowedComponentsContainer.tsx
+++ b/src/components/AllowedComponentsContainer.tsx
@@ -28,8 +28,7 @@ type Props = {
 const AllowedComponentsContainer = (props: Props): JSX.Element => {
   const { placeholderClassNames = '', allowedComponents, title } = props;
   const { components } = allowedComponents;
-  const emptyLabel = Texts.EMPTY_LABEL;
-  const listLabel = components && components.length > 0 ? title : emptyLabel;
+  const listLabel = components && components.length > 0 ? title : Texts.EMPTY_LABEL;
 
   return (
     <div className={`${ClassNames.ALLOWED_LIST_PLACEHOLDER} ${ClassNames.NEW_SECTION} ${placeholderClassNames}`}>
@@ -38,7 +37,7 @@ const AllowedComponentsContainer = (props: Props): JSX.Element => {
         <div
           data-cq-data-path={component.path}
           key={component.path}
-          data-emptytext={emptyLabel}
+          data-emptytext={component.title ? component.title : Texts.EMPTY_COMPONENT_TITLE}
           className={ClassNames.ALLOWED_COMPONENT_PLACEHOLDER}
         />
       ))}

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -18,4 +18,5 @@ export const Texts = Object.freeze({
    * The label to be displayed when no components are allowed in AllowedComponentsContainer
    */
   EMPTY_LABEL: 'No allowed components',
+  EMPTY_COMPONENT_TITLE: '–',
 });

--- a/test/components/AllowedComponentsContainer.test.tsx
+++ b/test/components/AllowedComponentsContainer.test.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import AllowedComponentsContainer from '../../src/components/AllowedComponentsContainer';
 import { AllowedComponentList } from '../../src/types/AEMModel';
+import { Texts } from '../../src/constants';
 
 describe('AllowedComponentsContainer ->', () => {
   const DEFAULT_TITLE = 'Layout Container';
@@ -82,6 +83,38 @@ describe('AllowedComponentsContainer ->', () => {
       expect(allowedComponentsTitle).toBeDefined();
       expect(allowedComponentsTitle.dataset.text).toEqual(DEFAULT_TITLE);
       expect(allowedComponentsContainer.querySelectorAll(ALLOWED_COMPONENT_PLACEHOLDER_SELECTOR).length).toEqual(2);
+    });
+  });
+
+  describe('AllowedComponentPlaceholder ->', () => {
+    const renderAllowedComponentPlaceholder = ({ title = null, path = '' }) => {
+      const allowedComponents: AllowedComponentList = {
+        applicable: true,
+        components: [
+          {
+            path,
+            title,
+          },
+        ],
+      };
+      render(generateAllowedComponentsContainer(allowedComponents));
+      const node = screen.getByTestId('testcontainer');
+      return node.querySelector(ALLOWED_COMPONENT_PLACEHOLDER_SELECTOR) as HTMLElement;
+    };
+
+    it('should contain title', () => {
+      const placeholder = renderAllowedComponentPlaceholder({ title: COMPONENT_TEXT_TITLE });
+      expect(placeholder.dataset.emptytext).toEqual(COMPONENT_TEXT_TITLE);
+    });
+
+    it('should contain empty title when none provided', () => {
+      const placeholder = renderAllowedComponentPlaceholder({});
+      expect(placeholder.dataset.emptytext).toEqual(Texts.EMPTY_COMPONENT_TITLE);
+    });
+
+    it('should contain path', () => {
+      const placeholder = renderAllowedComponentPlaceholder({ path: COMPONENT_TEXT_PATH });
+      expect(placeholder.dataset.cqDataPath).toEqual(COMPONENT_TEXT_PATH);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Allowed Component Placeholder shows component title if configured and falls-back to an empty title 
- Components allowed by the policy are correctly displayed in the Template Editor

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aem-guides-wknd-spa/issues/33
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
In Template Editor all allowed components show "No allowed components" instead of titles
![bug-in-template-editor](https://user-images.githubusercontent.com/537210/219426432-f5276366-7974-4e24-a669-fe5279aa2116.png)

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- unit tests added to the component

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![fix-no-components](https://user-images.githubusercontent.com/537210/219426439-52b0be18-31b0-4372-9749-eec44510ada4.png)
![fix-with-components](https://user-images.githubusercontent.com/537210/219426442-22e8bcfc-e057-4d74-9a25-d4b8fd4ffdf7.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
