### PR TITLE
issues/195 - Stylesystem Bugfix : Code refactored as per new design

### DIFF
--- a/src/core/EditableComponent.tsx
+++ b/src/core/EditableComponent.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Properties } from '../constants';
 import { Utils } from '../utils/Utils';
 import { AuthoringUtils, ModelManager } from '@adobe/aem-spa-page-model-manager';
-import { PageModel } from '../types/AEMModel';
+import { ModelProps } from '../types/AEMModel';
 import { Config, MappedComponentProperties } from '../types/EditConfig';
 import { useEditor } from '../hooks/useEditor';
 import Placeholder from '../components/Placeholder';
@@ -24,7 +24,7 @@ export type EditableComponentProps = {
   className?: string;
   appliedCssClassNames?: string;
   containerProps?: { className?: string };
-  model?: PageModel;
+  model?: ModelProps;
   pagePath?: string;
   itemPath?: string;
   removeDefaultStyles?: boolean;
@@ -47,7 +47,6 @@ export const EditableComponent = (editableProps: EditableComponentProps): JSX.El
     itemPath,
     isInEditor = AuthoringUtils.isInEditor(),
     className = '',
-    appliedCssClassNames = '',
     ...props
   } = editableProps;
   const { updateModel } = useEditor();
@@ -78,6 +77,7 @@ export const EditableComponent = (editableProps: EditableComponentProps): JSX.El
     }) ||
     {};
 
+  const {appliedCssClassNames = ''} = model; 
   const componentClassName = `${className} ${props.containerProps?.className || ''} ${appliedCssClassNames}`.trim();
 
   const updatedComponent = addPropsToComponent(children, pagePath ? componentProps : model);

--- a/src/core/EditableComponent.tsx
+++ b/src/core/EditableComponent.tsx
@@ -77,7 +77,7 @@ export const EditableComponent = (editableProps: EditableComponentProps): JSX.El
     }) ||
     {};
 
-  const {appliedCssClassNames = ''} = model; 
+  const { appliedCssClassNames = '' } = model;
   const componentClassName = `${className} ${props.containerProps?.className || ''} ${appliedCssClassNames}`.trim();
 
   const updatedComponent = addPropsToComponent(children, pagePath ? componentProps : model);

--- a/test/EditableComponent.test.tsx
+++ b/test/EditableComponent.test.tsx
@@ -32,7 +32,9 @@ describe('EditableComponent ->', () => {
   const CQ_PROPS = {
     cqType: COMPONENT_RESOURCE_TYPE,
     cqPath: COMPONENT_PATH,
-    appliedCssClassNames: CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME,
+    model: {
+      appliedCssClassNames: CHILD_COMPONENT_APPLIED_STYLE_CLASS_NAME,
+    },
     containerProps: {
       className: GRID_CLASS_NAME,
     },
@@ -69,7 +71,9 @@ describe('EditableComponent ->', () => {
   type Props = {
     cqType: string;
     cqPath: string;
-    appliedCssClassNames?: string;
+    model?: {
+      appliedCssClassNames?: string;
+    };
     containerProps: {
       className?: string;
     };
@@ -186,7 +190,8 @@ describe('EditableComponent ->', () => {
         render(createEditableComponent(EDIT_CONFIG));
       });
       const node = screen.getByTestId('childComponent').parentElement;
-      expect(node.classList.contains(CQ_PROPS.appliedCssClassNames)).toBeTruthy();
+      console.error(node?.classList);
+      expect(node.classList.contains(CQ_PROPS.model?.appliedCssClassNames)).toBeTruthy();
     });
 
     it('should not have any custom CSS classes if appliedCssClasses is empty or not set', () => {
@@ -197,7 +202,10 @@ describe('EditableComponent ->', () => {
         emptyLabel: EMPTY_LABEL,
         resourceType: COMPONENT_RESOURCE_TYPE,
       };
-      const { appliedCssClassNames, ...otherCQProps } = CQ_PROPS;
+      const {
+        model: { appliedCssClassNames },
+        ...otherCQProps
+      } = CQ_PROPS;
       act(() => {
         render(createEditableComponent(EDIT_CONFIG, true, otherCQProps));
       });


### PR DESCRIPTION
## Description
Existing code (v2.0.5) assumes appliedCssClassNames is available as a prop when obtaining component mapping. But with SPA 2.0 design the prop will be available only to children under EditableComponent. In addition, while authoring, when we change styles, model is updated, but EditableComponent doesn't recieve the new style info as our code is bound to model passed from parent e.g. container. With these inferences in mind, made changes below

- Accessing appliedCssClassNames via model prop as it is not available
- Enable applying styles dynamically while authoring
- Rely on model state for re-rendering with new classes while authoring

package.json with new version can be updated upon confirmation from approvers. Additional unit tests can be added if approvers deem necessary

## Related Issue
 #195 

## Motivation and Context

Same as description, as we all understand the power of stylesystem and keeping this feature supported is critical for us to upgrade to SPA 2.0 where one may choose to do a hybrid of SPA implementations e.g an entire help section coming from AEM as-is and other pages from React app share some sections that are editable via AEM

## How Has This Been Tested?

- Confirmed that the changes reflect when using Responsive Grid component and a normal container component covering scenarios of altering styles on container based comps and normal comps
- EditableComponent unit test has been modified with new structure of the data

## Screenshots (if appropriate):

- Issue link can be visited before this fix
- After the PR is merged below is the behavior for the usecase explained in issue.

### Inside AEM Editor with Changing Styles
Changed background of text from Skyblue to Gray
<img width="1420" alt="Screenshot 2023-07-27 at 7 23 39 AM" src="https://github.com/adobe/aem-react-editable-components/assets/34920377/c0ac6a39-0c85-4b0a-a863-8ad9c9759731">

<img width="1420" alt="Screenshot 2023-07-27 at 7 24 24 AM" src="https://github.com/adobe/aem-react-editable-components/assets/34920377/2b297eec-321b-4d9c-8e85-d4014cd8c2f2">

### View as Published Experience

<img width="1420" alt="Screenshot 2023-07-27 at 7 20 15 AM" src="https://github.com/adobe/aem-react-editable-components/assets/34920377/4de99ee2-67a4-4aba-bbf6-a640baa74585">

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
