### PR TITLE
feat(Container): Export childComponents as array. Fixes issue #189

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -15,6 +15,7 @@ import { Properties, ClassNames } from '../constants';
 import { ModelProps, PageModel } from '../types/AEMModel';
 import { ComponentMapping, MapTo } from '../core/ComponentMapping';
 import { Config, MappedComponentProperties } from '../types/EditConfig';
+import { AuthoringUtils } from '@adobe/aem-spa-page-model-manager';
 
 export type ContainerProps = {
   className?: string;
@@ -43,11 +44,37 @@ const getItemPath = (cqPath: string, itemKey: string, isPage = false): string =>
   return itemPath;
 };
 
-const ComponentList = ({ cqItemsOrder, cqItems, cqPath = '', getItemClassNames, isPage, ...props }: ContainerProps) => {
-  const componentMapping = props.componentMapping || ComponentMapping;
+const ComponentList = ({
+  cqItemsOrder,
+  cqItems,
+  cqPath = '',
+  getItemClassNames,
+  isPage,
+  removeDefaultStyles,
+  ...props
+}: ContainerProps) => {
   if (!cqItemsOrder || !cqItems || !cqItemsOrder.length) {
     return <></>;
   }
+
+  return (
+    <>
+      {getChildComponents({ cqItemsOrder, cqItems, cqPath, getItemClassNames, isPage, removeDefaultStyles, ...props })}
+    </>
+  );
+};
+
+export const getChildComponents = ({
+  cqItemsOrder = [],
+  cqItems = {},
+  cqPath = '',
+  getItemClassNames,
+  isPage,
+  removeDefaultStyles,
+  isInEditor = AuthoringUtils.isInEditor(),
+  ...props
+}: ContainerProps) => {
+  const componentMapping = props.componentMapping || ComponentMapping;
   const components: Array<ReactElement> = [];
   cqItemsOrder.forEach((itemKey: string) => {
     const itemProps = Utils.modelToProps(cqItems[itemKey]);
@@ -61,8 +88,10 @@ const ComponentList = ({ cqItemsOrder, cqItems, cqPath = '', getItemClassNames, 
             key={itemPath}
             model={itemProps}
             cqPath={itemPath}
+            isInEditor={isInEditor}
+            componentMapping={componentMapping}
             className={itemClassNames}
-            removeDefaultStyles={props.removeDefaultStyles}
+            removeDefaultStyles={removeDefaultStyles}
           />,
         );
       } else {

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -24,7 +24,7 @@ export type ContainerProps = {
   childPages?: JSX.Element;
   getItemClassNames?: (_key: string) => string;
   placeholderClassNames?: string;
-  isInEditor: boolean;
+  isInEditor?: boolean;
   componentMapping?: typeof ComponentMapping;
   removeDefaultStyles?: boolean;
   config?: Config<MappedComponentProperties>;
@@ -73,7 +73,7 @@ export const getChildComponents = ({
   removeDefaultStyles,
   isInEditor = AuthoringUtils.isInEditor(),
   ...props
-}: ContainerProps) => {
+}: ContainerProps): ReactElement[] => {
   const componentMapping = props.componentMapping || ComponentMapping;
   const components: Array<ReactElement> = [];
   cqItemsOrder.forEach((itemKey: string) => {
@@ -99,7 +99,7 @@ export const getChildComponents = ({
       }
     }
   });
-  return <>{components}</>;
+  return components;
 };
 
 export const Container = (props: ContainerProps): JSX.Element => {
@@ -107,7 +107,7 @@ export const Container = (props: ContainerProps): JSX.Element => {
     cqPath = '',
     className = '',
     isPage = false,
-    isInEditor,
+    isInEditor = AuthoringUtils.isInEditor(),
     childPages,
     placeholderClassNames = '',
     components,

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -64,6 +64,12 @@ const ComponentList = ({
   );
 };
 
+/**
+ * Retrieves the child components from the container.
+ * @summary Retrieves the child components from the cqItems and cqItemsOrder for use in custom containers like Tabs, Carousel, Accordion, etc.
+ * @param {ContainerProps} props
+ * @returns {JSX.Element} Array of child components ready to be rendered
+ */
 export const getChildComponents = ({
   cqItemsOrder = [],
   cqItems = {},

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -63,7 +63,7 @@ For default SPA on AEM, the component can be used as-is OOTB.
 ### Remote SPA
 When using the component directly within the app for remote SPA, two additional props _pagePath_ and _itemPath_ can be used to pass the path of the corresponding content on AEM.
 
-```
+```jsx
 <ResponsiveGrid 
   pagePath='/content/wknd-app/us/en/home'
   itemPath='root/responsivegrid' />
@@ -78,12 +78,75 @@ The ResponsiveGrid component can still be used if content does not exist yet on 
 
 If a custom class name needs to be added to the OOTB ResponsiveGrid component, this can be done by passing in the class names as a string via the prop _customClassName_
 
-```
+```jsx
 <ResponsiveGrid 
   pagePath='/content/wknd-app/us/en/home'
   itemPath='root/responsivegrid'
   customClassName='newUserStyleClass' />
 ```
+
+
+## Container
+
+For all container components other than ResponsiveGrid, you can either use the Container component as-is or use the helper method _getChildComponents()_ and then render them according to the markup requirements.
+
+### Default SPA
+Lets say you want to use the WCM Core Container component, and based on user's selection it can either be a _ResponsiveGrid_ or a normal _Container_. 
+
+Here is a sample snippet of how it can be acheived.
+
+```jsx
+const MyContainerEditConfig = {
+  emptyLabel: 'Container',
+  isEmpty: function(props){
+    return !props.cqItemsOrder || !props.cqItemsOrder.length ===0
+  }
+}
+
+const MyContainer = (props) => 
+{
+  const MyComponent = (props.layout!=="SIMPLE")?ResponsiveGrid:Container;
+  return <MyComponent {...props} />;
+}
+
+MapTo('/wknd/components/content/container')(MyContainer, MyContainerEditConfig);
+```
+
+Now lets say you want to render a custom markup for your container, example - a component like Tabs which is also a container, then the sample snippet above can be refactored.
+
+```jsx
+const MyTabsEditConfig = {
+  emptyLabel: 'Tabs',
+  isEmpty: function(props){
+    return !props.cqItemsOrder || !props.cqItemsOrder.length ===0
+  }
+}
+
+const MyTabs = (props) => 
+{
+  const tabItemsInOrder = Container.getChildComponents(props);
+
+  const tabItemsJsx = tabItemsInOrder.map((tabItemJsx) =><div className="tab-item">{tabItemJsx}</div>);
+
+  return <div className="tabs">${tabItemsJsx}</div>;
+}
+
+MapTo('/wknd/components/content/tabs')(MyTabs, MyTabsEditConfig);
+```
+
+#### Migration to v2
+
+Before SPA 2.0, Container component is a class based component an it required the consumers to instantiate the class or use class based inheritance to ontain the child components e.g. this.childComponents in your custom implementation loaded all the child components as an array. Now this needs to be replaced with the helper method as shown in sample snippet above.
+
+### Remote SPA
+
+```jsx
+<Container 
+  pagePath='/content/wknd-app/us/en/home'
+  itemPath='root/responsivegrid/container' />
+```
+
+For a custom container, you shall be able to adopt same guidelines followed for normal SPA.
 
 # Additional Features
 
@@ -91,7 +154,7 @@ If a custom class name needs to be added to the OOTB ResponsiveGrid component, t
 
 If the model for rendering the component has already been fetched (for eg: in SSR), this can be passed into the component via a prop, so that the component doesn't need to fetch it again on the client side.
 
-```
+```jsx
 const App = ({ model }) => (
   <ResponsiveGrid 
     pagePath='/content/wknd-app/us/en/home'
@@ -103,7 +166,7 @@ const App = ({ model }) => (
 ### Remove AEM grid styling
 AEM layouting styles are applied by default when using the ResponsiveGrid and Page components. If you would prefer to use your own custom layouting over the AEM authored layouts, an additional prop _removeDefaultStyles_ can be passed into the components.
 
-```
+```jsx
 <ResponsiveGrid 
   pagePath='/content/wknd-app/us/en/home'
   itemPath='root/responsivegrid'
@@ -117,7 +180,7 @@ Mapping child components to a container component can now be done via a prop ins
 
 If the container components has 2 child components, _Text_ and _Image_ of resource type _wknd/text_ and _wknd/image_ respectively, these can now be mapped to a grid component as below - 
 
-```
+```jsx
 <ResponsiveGrid 
   pagePath='/content/wknd-app/us/en/home'
   itemPath='root/responsivegrid'
@@ -157,7 +220,7 @@ MapTo('wknd/text')(React.lazy(() => import('./components/Text')));
 
 #### _components_ Prop
 
-```
+```jsx
 <ResponsiveGrid 
   ...
   components={{
@@ -166,7 +229,7 @@ MapTo('wknd/text')(React.lazy(() => import('./components/Text')));
 ```
 can be updated to lazy load the child components on usage as below - 
 
-```
+```jsx
 <ResponsiveGrid 
   ...
   components={{

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -14,14 +14,14 @@ For default SPA on AEM, the component can be used as-is OOTB.
 
 - *ComponentMappingContent* is now handled internally, so the [usage as illustrated in the sample WKND project](https://github.com/adobe/aem-guides-wknd-spa/blob/React/latest/ui.frontend/src/components/Page/Page.js) as - 
 
-```
+```js
 export default MapTo('wknd-spa-react/components/page')(
   withComponentMappingContext(withRoute(AppPage))
 );
 ```
 
 can be simplified and now instead be -
-```
+```js
 export default MapTo('wknd-spa-react/components/page')(
   withRoute(AppPage)
 );
@@ -29,20 +29,20 @@ export default MapTo('wknd-spa-react/components/page')(
 
 - *Model fetching* is now handled internally, so [the usage of withModel](https://github.com/adobe/aem-guides-wknd-spa/blob/React/latest/ui.frontend/src/App.js#L16)  - 
 
-```
+```js
 export default withModel(App);
 ```
 
 can be removed and can be used simply as -
 
-```
+```js
 export default App;
 ```
 
 ### Remote SPA
 When using the component directly within the app for remote SPA, an additional prop _pagePath_ can be used to pass the path of the corresponding page on AEM.
 
-```
+```jsx
 <Page 
   pagePath='/content/wknd-app/us/en/home' />
 ```
@@ -128,7 +128,7 @@ const MyTabs = (props) =>
 
   const tabItemsJsx = tabItemsInOrder.map((tabItemJsx) =><div className="tab-item">{tabItemJsx}</div>);
 
-  return <div className="tabs">${tabItemsJsx}</div>;
+  return <div className="tabs">{tabItemsJsx}</div>;
 }
 
 MapTo('/wknd/components/content/tabs')(MyTabs, MyTabsEditConfig);

--- a/test/components/Container.test.tsx
+++ b/test/components/Container.test.tsx
@@ -119,6 +119,47 @@ describe('Container ->', () => {
       expect(jsxList.length).toBe(0);
     });
 
+    it('should return an empty JSX if incoming model json has empty items', () => {
+      ComponentMappingSpy.mockReturnValue(ComponentChild);
+      render(
+        <div data-testid="testcontainer">
+          <Container
+            {...{
+              cqPath: '/some/path',
+              cqType: '/some/type',
+              removeDefaultStyles: true,
+              cqItems: {},
+              cqItemsOrder: [],
+            }}
+          />
+        </div>,
+      );
+      const node = screen.getByTestId('testcontainer');
+      expect(node).not.toBeNull();
+      expect(node.getElementsByClassName('aem-container').length).toBe(0);
+    });
+
+    it('should return an empty JSX if incoming model json has empty items when isInEditor is set', () => {
+      ComponentMappingSpy.mockReturnValue(ComponentChild);
+      render(
+        <div data-testid="testcontainer">
+          <Container
+            {...{
+              cqPath: '/some/path',
+              cqType: '/some/type',
+              isInEditor: true,
+              removeDefaultStyles: true,
+              cqItems: {},
+              cqItemsOrder: [],
+            }}
+          />
+        </div>,
+      );
+      const node = screen.getByTestId('testcontainer');
+      expect(node).not.toBeNull();
+      expect(node.getElementsByClassName('aem-container').length).toBe(1);
+    });
+
     it('should render available components if some are unmapped', () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/test/components/Container.test.tsx
+++ b/test/components/Container.test.tsx
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import { ComponentMapping } from '../../src/core/ComponentMapping';
-import { Container } from '../../src/components/Container';
+import { Container, getChildComponents } from '../../src/components/Container';
 
 describe('Container ->', () => {
   const CONTAINER_PLACEHOLDER_SELECTOR = '.new.section';
@@ -107,6 +107,18 @@ describe('Container ->', () => {
       expect(node.querySelector('#c1')).toBeNull();
       expect(node.querySelector('#c2')).toBeNull();
     });
+
+    it('should return an empty array of JSX if incoming model json doesnt meet container props', () => {
+      ComponentMappingSpy.mockReturnValue(ComponentChild);
+
+      const jsxList: ReactElement[] = getChildComponents({
+        cqType: '/some/type',
+        removeDefaultStyles: true,
+      });
+
+      expect(jsxList.length).toBe(0);
+    });
+
     it('should render available components if some are unmapped', () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Description

SPA 2.0 Impl refactored all existing class based comps to functional comps. In the process the ability to obtain child components in custom components like tabs, accordion and carousel are lost as the default markup generated by container or responsivegrid components doesnt fit the need. This PR addresses this issue by decoupling the logic to consolidate all children into an array via a utility method and calling the same in Container's render. Now the utility method is exported as well so consumers can continue to use similar logic as we did before SPA 2.0

## Related Issue
#189 

## Motivation and Context
Explained in description and reported issue.

## How Has This Been Tested?

We were able to rebuild tabs component using the changes suggested. Also the OOTB container and Responsivegrid components also worked as desired.

## Screenshots (if appropriate):
If needed I can build a sample and attach screenshots. As the React Core Comps SPA repo is not migrated to SPA 2.0 we dont have an easy way to share the issue in a generic codebase like WKND SPA.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Addl unit tests are not included as the existing tests cover this method. If desired, we can add them on request from approvers.

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
